### PR TITLE
成果報告動画を掲載

### DIFF
--- a/src/components/Works.vue
+++ b/src/components/Works.vue
@@ -82,7 +82,6 @@ export default {
     }
     iframe {
       width: 90%;
-      
     }
   }
 }

--- a/src/components/Works.vue
+++ b/src/components/Works.vue
@@ -4,6 +4,29 @@
       <span class="heading__main-text">Works</span>
     </h2>
     <div class="works_container">
+      <div class="text">
+        <h3 class="text_sub">成果報告映像</h3>
+        <p class="text_black">
+          本年度の藤原プロジェクトの活動とその成果をまとめた映像です。
+        </p>
+      </div>
+      <iframe
+        loading="lazy"
+        width="560"
+        height="315"
+        src="https://www.youtube.com/embed/mM80fjQZOU8"
+        frameborder="0"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; fullscreen; gyroscope; picture-in-picture"
+        referrerpolicy="no-referrer"></iframe>
+    </div>
+
+    <div class="works_container">
+      <div class="text">
+        <h3 class="text_sub">動画シリーズ</h3>
+        <p class="text_black">
+          YouTubeで公開している、天ノ葉つむぎと武者丸の動画シリーズです。
+        </p>
+      </div>
       <iframe
         loading="lazy"
         width="560"
@@ -12,16 +35,8 @@
         frameborder="0"
         allow="accelerometer; autoplay; clipboard-write; encrypted-media; fullscreen; gyroscope; picture-in-picture"
         referrerpolicy="no-referrer"></iframe>
-      <iframe
-        loading="lazy"
-        width="560"
-        height="315"
-        frameborder="0"
-        src="https://www.youtube.com/embed/?list=UU6sjImHi5w_9mVVfkXauF3g"
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; fullscreen; gyroscope; picture-in-picture"
-        referrerpolicy="no-referrer"
-      ></iframe>
     </div>
+
   </div>
 </template>
 
@@ -36,8 +51,39 @@ export default {
 .works {
   &_container {
     display: flex;
+    flex-direction: row-reverse;
     justify-content: space-between;
     margin-bottom: 40px;
+    iframe {
+      flex-basis: 60%;
+    }
+    .text {
+      display: block;
+      flex-basis: 40%;
+      padding: 4%;
+
+      h3 {
+        margin: 0;
+        font-size: 24px;
+      }
+
+      p {
+        margin-top: 25px;
+      }
+    }
+  }
+}
+@media screen and (max-width: $break-point) {
+  .works {
+    &_container {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+    iframe {
+      width: 90%;
+      
+    }
   }
 }
 </style>


### PR DESCRIPTION
やったこと
- 紹介動画を埋め込み
- それにともなって体裁を整えるために動画シリーズの紹介を再生リストの埋め込み1つに変更
- レスポンシブ対応

![スクリーンショット 2021-01-29 19 51 18](https://user-images.githubusercontent.com/46423355/106266709-1e57e980-626c-11eb-9ffc-4f56d9c6810d.png)
![IMG_5810](https://user-images.githubusercontent.com/46423355/106266720-22840700-626c-11eb-8c9b-a6feb3a17766.jpg)

独断でこういう感じにしたけど、オリジナルグッズ紹介やLINEスタンプ紹介も同じように画像と説明で追加すれば簡単にコンテンツ増やせそうだなとおもって

close #63 